### PR TITLE
Modified to support MO clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Unit Tests Status](https://github.com/ElectroRoute-Japan/mms-client/actions/workflows/check.yml/badge.svg)](https://github.com/ElectroRoute-Japan/mms-client/actions)
 
 # Overview
-This repository contains a Python client that is capable of communication with the Market Management System (MMS), which handles requests related to Flex or Virtual Power Plant (VPP) trading. The underlying library is relies on SOAP communication, which is a pain to work with at the best of times. This particular SOAP API adds its own special layer of obnoxiousness, however. As such, it was deemed useful to have a client which would obfuscate most, if not all of this away from the user.
+This repository contains a Python client that is capable of communication with the Market Management System (MMS), which handles requests related to Flex or Virtual Power Plant (VPP) trading. The underlying library relies on SOAP communication, which is a pain to work with at the best of times. This particular SOAP API adds its own special layer of obnoxiousness, however. As such, it was deemed useful to have a client which would obfuscate most, if not all of this away from the user.
 
 # Communication
 The underlying API sends and receives XML documents. Each of these request or responses, which we will hereafter refer to as *outer* requests and responses, contains metadata about the request/response as well as three fields which are extremely important to successful communication with the API:
@@ -15,7 +15,9 @@ After the data has been converted and added to the outer request object, it is s
 This library relies on Pydantic 2 and the pydantic-xml library for serialization/deserialization. As such, any type in this library can be converted to not only XML, but to JSON as well. This is extremely useful if you're trying to build a pass-through API service or something similar.
 
 ## Client Types
-Clients cannot call any and all endpoints in this API, willy-nilly. Some endpoints are restricted to particular clients. At the moment, there are two clients: Balance Service Providers (BSPs) and Transmission Service Operators (TSOs). Most likely you're operating as a BSP, in which case you'll have access to all endpoints. However, it makes little sense for a TSO to be able to submit bids on their own power, so they are restricted to a read-only role in most cases.
+Clients cannot call any and all endpoints in this API, willy-nilly. Some endpoints are restricted to particular clients. At the moment, there are three clients: Balance Service Providers (BSPs), Market Operators (MOs), and Transmission Service Operators (TSOs). Most likely you're operating as a BSP or MO, in which case you'll have access to most or all endpoints. However, it makes little sense for a TSO to be able to submit bids on their own power, so they are restricted to a read-only role in most cases.
+
+Note that MOs and BSPs access the MMS service using the same endpoints, but have distinct permissions. As such, both client types are supported explicitly here.
 
 Should you request an endpoint which you are not authorized for, you will receive an `mms_client.utils.errors.AudienceError`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mms_client"
-version = "v1.4.0"
+version = "v1.4.1"
 description = "API client for accessing the MMS"
 authors = ["Ryan Wood <ryan.wood@electroroute.co.jp>"]
 readme = "README.md"

--- a/src/mms_client/services/base.py
+++ b/src/mms_client/services/base.py
@@ -322,7 +322,7 @@ class BaseClient:  # pylint: disable=too-many-instance-attributes
             f"{config.name}: Verifying audience. Allowed clients: "
             f"{config.allowed_clients if config.allowed_clients else 'Any'}."
         )
-        if config.allowed_clients and self._client_type not in config.allowed_clients:
+        if config.allowed_clients and (self._client_type not in config.allowed_clients):
             raise AudienceError(config.name, config.allowed_clients, self._client_type)
 
     def request_one(

--- a/src/mms_client/services/base.py
+++ b/src/mms_client/services/base.py
@@ -59,7 +59,7 @@ class EndpointConfiguration(Generic[E, P]):
     name: str
 
     # The allowed client types for the endpoint
-    allowed_client: Optional[ClientType]
+    allowed_clients: Optional[List[ClientType]]
 
     # The service for the endpoint
     service: ServiceConfiguration
@@ -139,7 +139,7 @@ def mms_endpoint(
     name: str,
     service: ServiceConfiguration,
     request_type: RequestType,
-    allowed_client: Optional[ClientType] = None,
+    allowed_clients: Optional[List[ClientType]] = None,
     resp_envelope_type: Optional[Type[E]] = None,
     resp_data_type: Optional[Type[P]] = None,
 ):
@@ -150,18 +150,18 @@ def mms_endpoint(
     Decorated functions will only be responsible for creating the payload envelope to submit to the MMS server.
 
     Arguments:
-    name (str):                     The name of the endpoint.
-    service (ServiceConfiguration): The configuration for the service.
-    request_type (RequestType):     The type of request to submit to the MMS server.
-    allowed_client (ClientType):    The type of client that is allowed to access the endpoint. If this is not provided,
-                                    then any client type is allowed.
-    resp_envelope_type (Type[E]):   The type of payload to expect in the response. If this is not provided, then the
-                                    the response envelope will be assumed to have the same type as the request envelope.
-    resp_data_type (Type[P]):       The type of data to expect in the response. If this is not provided, then the
-                                    response data will be assumed to have the same type as the request data.
+    name (str):                         The name of the endpoint.
+    service (ServiceConfiguration):     The configuration for the service.
+    request_type (RequestType):         The type of request to submit to the MMS server.
+    allowed_clients (List[ClientType]): The types of clients that are allowed to access the endpoint. If this is not
+                                        provided, then any client will be allowed.
+    resp_envelope_type (Type[E]):       The type of payload to expect in the response. If this is not provided, then the
+                                        response envelope will be assumed to have the same type as the request envelope.
+    resp_data_type (Type[P]):           The type of data to expect in the response. If this is not provided, then the
+                                        response data will be assumed to have the same type as the request data.
     """
     # First, create the endpoint configuration from the given parameters
-    config = EndpointConfiguration(name, allowed_client, service, request_type, resp_envelope_type, resp_data_type)
+    config = EndpointConfiguration(name, allowed_clients, service, request_type, resp_envelope_type, resp_data_type)
 
     # Next, create a decorator that will add the endpoint configuration to the function
     def decorator(func):
@@ -189,7 +189,7 @@ def mms_multi_endpoint(
     name: str,
     service: ServiceConfiguration,
     request_type: RequestType,
-    allowed_client: Optional[ClientType] = None,
+    allowed_clients: Optional[List[ClientType]] = None,
     resp_envelope_type: Optional[Type[E]] = None,
     resp_data_type: Optional[Type[P]] = None,
 ):
@@ -201,21 +201,22 @@ def mms_multi_endpoint(
     the MMS server.
 
     Arguments:
-    name (str):                     The name of the endpoint.
-    service (ServiceConfiguration): The configuration for the service.
-    request_type (RequestType):     The type of request to submit to the MMS server.
-    allowed_client (ClientType):    The type of client that is allowed to access the endpoint. If this is not provided,
-                                    then any client type is allowed.
-    resp_envelope_type (Type[E]):   The type of payload to expect in the response. If this is not provided, then the
-                                    the response envelope will be assumed to have the same type as the request envelope.
-    resp_data_type (Type[P]):       The type of data to expect in the response. If this is not provided, then the
-                                    response data will be assumed to have the same type as the request data. Note, that
-                                    this is not intended to account for the expected sequence type of the response data.
-                                    That is already handled in the wrapped function, so this should only be set if the
-                                    inner data type being returned differs from what was sent.
+    name (str):                         The name of the endpoint.
+    service (ServiceConfiguration):     The configuration for the service.
+    request_type (RequestType):         The type of request to submit to the MMS server.
+    allowed_clients (List[ClientType]): The types of clients that are allowed to access the endpoint. If this is not
+                                        provided, then any client will be allowed.
+    resp_envelope_type (Type[E]):       The type of payload to expect in the response. If this is not provided, then
+                                        the response envelope will be assumed to have the same type as the request
+                                        envelope.
+    resp_data_type (Type[P]):           The type of data to expect in the response. If this is not provided, then the
+                                        response data will be assumed to have the same type as the request data. Note,
+                                        that this is not intended to account for the expected sequence type of the
+                                        response data. That is already handled in the wrapped function, so this should
+                                        only be set if the inner data type being returned differs from what was sent.
     """
     # First, create the endpoint configuration from the given parameters
-    config = EndpointConfiguration(name, allowed_client, service, request_type, resp_envelope_type, resp_data_type)
+    config = EndpointConfiguration(name, allowed_clients, service, request_type, resp_envelope_type, resp_data_type)
 
     # Next, create a decorator that will add the endpoint configuration to the function
     def decorator(func):
@@ -318,11 +319,11 @@ class BaseClient:  # pylint: disable=too-many-instance-attributes
         ValueError: If the client type is not allowed.
         """
         self._logger.debug(
-            f"{config.name}: Verifying audience. Allowed client: "
-            f"{config.allowed_client.name if config.allowed_client else 'Any'}."
+            f"{config.name}: Verifying audience. Allowed clients: "
+            f"{config.allowed_clients if config.allowed_clients else 'Any'}."
         )
-        if config.allowed_client and self._client_type != config.allowed_client:
-            raise AudienceError(config.name, config.allowed_client, self._client_type)
+        if config.allowed_clients and self._client_type not in config.allowed_clients:
+            raise AudienceError(config.name, config.allowed_clients, self._client_type)
 
     def request_one(
         self,

--- a/src/mms_client/services/market.py
+++ b/src/mms_client/services/market.py
@@ -30,7 +30,7 @@ class MarketClientMixin:  # pylint: disable=unused-argument
     # The configuration for the market service
     config = ServiceConfiguration(Interface.MI, Serializer(SchemaType.MARKET, "MarketData"))
 
-    @mms_endpoint("MarketSubmit_OfferData", config, RequestType.INFO, ClientType.BSP)
+    @mms_endpoint("MarketSubmit_OfferData", config, RequestType.INFO, [ClientType.BSP])
     def put_offer(
         self: ClientProto, request: OfferData, market_type: MarketType, days: int, date: Optional[Date] = None
     ) -> OfferData:
@@ -56,7 +56,7 @@ class MarketClientMixin:  # pylint: disable=unused-argument
             days=days,
         )
 
-    @mms_multi_endpoint("MarketSubmit_OfferData", config, RequestType.INFO, ClientType.BSP)
+    @mms_multi_endpoint("MarketSubmit_OfferData", config, RequestType.INFO, [ClientType.BSP])
     def put_offers(
         self: ClientProto, requests: List[OfferData], market_type: MarketType, days: int, date: Optional[Date] = None
     ) -> List[OfferData]:
@@ -106,7 +106,7 @@ class MarketClientMixin:  # pylint: disable=unused-argument
             days=days,
         )
 
-    @mms_endpoint("MarketCancel_OfferCancel", config, RequestType.INFO, ClientType.BSP)
+    @mms_endpoint("MarketCancel_OfferCancel", config, RequestType.INFO, [ClientType.BSP])
     def cancel_offer(
         self: ClientProto, request: OfferCancel, market_type: MarketType, days: int, date: Optional[Date] = None
     ) -> OfferCancel:

--- a/src/mms_client/services/registration.py
+++ b/src/mms_client/services/registration.py
@@ -27,7 +27,7 @@ class RegistrationClientMixin:  # pylint: disable=unused-argument
     # The configuration for the registration service
     config = ServiceConfiguration(Interface.MI, Serializer(SchemaType.REGISTRATION, "RegistrationData"))
 
-    @mms_endpoint("RegistrationSubmit_Resource", config, RequestType.REGISTRATION, ClientType.BSP)
+    @mms_endpoint("RegistrationSubmit_Resource", config, RequestType.REGISTRATION, [ClientType.BSP])
     def put_resource(self: ClientProto, request: ResourceData) -> ResourceData:
         """Submit a new resource to the MMS server.
 
@@ -50,6 +50,7 @@ class RegistrationClientMixin:  # pylint: disable=unused-argument
         "RegistrationQuery_Resource",
         config,
         RequestType.REGISTRATION,
+        allowed_clients=[ClientType.BSP, ClientType.TSO],
         resp_envelope_type=RegistrationSubmit,
         resp_data_type=ResourceData,
     )

--- a/src/mms_client/utils/errors.py
+++ b/src/mms_client/utils/errors.py
@@ -14,7 +14,7 @@ from mms_client.utils.web import ClientType
 class AudienceError(ValueError):
     """Error raised when an invalid audience is provided."""
 
-    def __init__(self, method: str, allowed: ClientType, audience: ClientType):
+    def __init__(self, method: str, allowed: List[ClientType], audience: ClientType):
         """Initialize the error.
 
         Arguments:
@@ -22,8 +22,13 @@ class AudienceError(ValueError):
         allowed (str):  The allowed audience.
         audience (str): The invalid audience.
         """
+        inner = (
+            f"'{allowed[0].name}' is"
+            if len(allowed) == 1
+            else f"""{" or ".join([f"'{a.name}'" for a in allowed])} are"""
+        )
         self.method = method
-        self.message = f"{method}: Invalid client type, '{audience.name}' provided. Only '{allowed.name}' is supported."
+        self.message = f"{method}: Invalid client type, '{audience.name}' provided. Only {inner} supported."
         self.allowed = allowed
         self.audience = audience
         super().__init__(self.message)

--- a/tests/test_client/test_registration.py
+++ b/tests/test_client/test_registration.py
@@ -381,6 +381,29 @@ def test_put_resource_works(mock_certificate):
     )
 
 
+def test_query_resources_invalid_client(mock_certificate):
+    """Test that the query_resources method raises an exception when called by a non-BSP client."""
+    # First, create our MMS client
+    client = MmsClient("F100", "FAKEUSER", ClientType.MO, mock_certificate, test=True)
+
+    # Next, create our test resource query
+    query = ResourceQuery(
+        participant="F100",
+        name="FAKE_RESO",
+        status=Status.APPROVED,
+    )
+
+    # Now, try to query resources; this should raise an exception
+    with pytest.raises(ValueError) as ex_info:
+        _ = client.query_resources(query, QueryAction.NORMAL, Date(2024, 4, 11))
+
+    # Finvally, verify the details of the raised exception
+    assert (
+        str(ex_info.value)
+        == "RegistrationQuery_Resource: Invalid client type, 'MO' provided. Only 'BSP' or 'TSO' are supported."
+    )
+
+
 @responses.activate
 def test_query_resources_works(mock_certificate):
     """Test that the query_resources method works as expected."""


### PR DESCRIPTION
This PR includes a minor refactor to split MO client roles out. There are some routes that TSOs are allowed to use but which are denied to MOs so the roles had to be separated.