### PR TITLE
Added reserve requirements query

### DIFF
--- a/src/mms_client/types/reserve.py
+++ b/src/mms_client/types/reserve.py
@@ -1,0 +1,71 @@
+"""Contains objects for MMS reserve requirements."""
+
+from typing import List
+from typing import Optional
+
+from pydantic_extra_types.pendulum_dt import DateTime
+from pydantic_xml import attr
+from pydantic_xml import element
+
+from mms_client.types.base import Payload
+from mms_client.types.enums import AreaCode
+from mms_client.types.enums import Direction
+from mms_client.types.fields import power_positive
+from mms_client.types.market import MarketType
+
+
+class Requirement(Payload):
+    """Represents a reserve requirement."""
+
+    # The start block of the requirement
+    start: DateTime = attr(name="StartTime")
+
+    # The end block of the requirement
+    end: DateTime = attr(name="EndTime")
+
+    # The direction of the requirement
+    direction: Direction = attr(name="Direction")
+
+    # The primary reserve quantity in kW
+    primary_qty_kw: Optional[int] = power_positive("PrimaryReserveQuantityInKw", True)
+
+    # The first secondary reserve quantity in kW
+    secondary_1_qty_kw: Optional[int] = power_positive("Secondary1ReserveQuantityInKw", True)
+
+    # The second secondary reserve quantity in kW
+    secondary_2_qty_kw: Optional[int] = power_positive("Secondary2ReserveQuantityInKw", True)
+
+    # The first tertiary reserve quantity in kW
+    tertiary_1_qty_kw: Optional[int] = power_positive("Tertiary1ReserveQuantityInKw", True)
+
+    # The second tertiary reserve quantity in kW
+    tertiary_2_qty_kw: Optional[int] = power_positive("Tertiary2ReserveQuantityInKw", True)
+
+    # The minimum reserve of compound primary and secondary 1 in kW
+    primary_secondary_1_qty_kw: Optional[int] = power_positive("CompoundPriSec1ReserveQuantityInKw", True)
+
+    # The minimum reserve of compound primary and secondary 2 in kW
+    primary_secondary_2_qty_kw: Optional[int] = power_positive("CompoundPriSec2ReserveQuantityInKw", True)
+
+    # The minimum reserve of compound primary and tertiary 1 in kW
+    primary_tertiary_1_qty_kw: Optional[int] = power_positive("CompoundPriTer1ReserveQuantityInKw", True)
+
+
+class ReserveRequirement(Payload):
+    """Represents a set of reserve requirements."""
+
+    # The area for which the reserve requirement applies
+    area: AreaCode = attr(name="Area")
+
+    # The requirements associated with the area
+    requirements: List[Requirement] = element(tag="Requirement", min_length=1)
+
+
+class ReserveRequirementQuery(Payload):
+    """Represents a request to query reserve requirements."""
+
+    # The market type for which to query reserve requirements
+    market_type: MarketType = attr(name="MarketType")
+
+    # The area for which to query reserve requirements
+    area: Optional[AreaCode] = attr(default=None, name="Area")

--- a/tests/test_files/query_reserve_requirements_request.xml
+++ b/tests/test_files/query_reserve_requirements_request.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='utf-8'?>
+<MarketData xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="mi-market.xsd">
+    <MarketQuery Date="2024-04-12" ParticipantName="F100" UserName="FAKEUSER" NumOfDays="1">
+        <ReserveRequirementQuery MarketType="DAM" Area="03"/>
+    </MarketQuery>
+</MarketData>

--- a/tests/test_files/query_reserve_requirements_response.xml
+++ b/tests/test_files/query_reserve_requirements_response.xml
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='utf-8'?>
+<MarketData xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <ProcessingStatistics Received="1" Valid="1" Invalid="0" Successful="1" Unsuccessful="0" ProcessingTimeMs="187" TransactionId="derpderp" TimeStamp="Tue Mar 15 11:43:37 JST 2024" XmlTimeStamp="2024-03-15T11:43:37" />
+    <Messages>
+        <Warning Code="Warning1" />
+        <Warning Code="Warning2" />
+        <Information Code="Info1" />
+        <Information Code="Info2" />
+    </Messages>
+    <MarketSubmit Date="2024-04-12" ParticipantName="F100" UserName="FAKEUSER" NumOfDays="1" Validation="PASSED" Success="true">
+        <Messages>
+            <Warning Code="Warning1" />
+            <Warning Code="Warning2" />
+            <Information Code="Info1" />
+            <Information Code="Info2" />
+        </Messages>
+        <ReserveRequirement Area="03">
+            <Requirement
+             StartTime="2024-04-12T15:00:00"
+             EndTime="2024-04-12T18:00:00"
+             Direction="1"
+             PrimaryReserveQuantityInKw="100"
+             Secondary1ReserveQuantityInKw="200"
+             Secondary2ReserveQuantityInKw="300"
+             Tertiary1ReserveQuantityInKw="400"
+             Tertiary2ReserveQuantityInKw="500"
+             CompoundPriSec1ReserveQuantityInKw="600"
+             CompoundPriSec2ReserveQuantityInKw="700"
+             CompoundPriTer1ReserveQuantityInKw="800"/>
+        </ReserveRequirement>
+    </MarketSubmit>
+</MarketData>

--- a/tests/test_files/reserve_requirement_full.xml
+++ b/tests/test_files/reserve_requirement_full.xml
@@ -1,0 +1,14 @@
+<ReserveRequirement Area="03">
+    <Requirement
+     StartTime="2024-04-12T15:00:00"
+     EndTime="2024-04-12T18:00:00"
+     Direction="1"
+     PrimaryReserveQuantityInKw="100"
+     Secondary1ReserveQuantityInKw="200"
+     Secondary2ReserveQuantityInKw="300"
+     Tertiary1ReserveQuantityInKw="400"
+     Tertiary2ReserveQuantityInKw="500"
+     CompoundPriSec1ReserveQuantityInKw="600"
+     CompoundPriSec2ReserveQuantityInKw="700"
+     CompoundPriTer1ReserveQuantityInKw="800"/>
+</ReserveRequirement>

--- a/tests/test_types/test_reserve.py
+++ b/tests/test_types/test_reserve.py
@@ -1,0 +1,110 @@
+"""Tests the functionality in the mms_client.types.reserve module."""
+
+from pydantic_extra_types.pendulum_dt import DateTime
+
+from mms_client.types.enums import AreaCode
+from mms_client.types.enums import Direction
+from mms_client.types.market import MarketType
+from mms_client.types.reserve import Requirement
+from mms_client.types.reserve import ReserveRequirement
+from mms_client.types.reserve import ReserveRequirementQuery
+from tests.testutils import read_request_file
+from tests.testutils import requirement_verifier
+from tests.testutils import verify_reserve_requirement
+from tests.testutils import verify_reserve_requirement_query
+
+
+def test_reserve_requirement_query_defaults():
+    """Test that the ReserveRequirementQuery class initializes and converts to XML as expected."""
+    # First, create a new reserve requirement query request
+    request = ReserveRequirementQuery(
+        market_type=MarketType.DAY_AHEAD,
+    )
+
+    # Next, convert the request to XML
+    data = request.to_xml(skip_empty=True, encoding="utf-8")
+
+    # Finally, verify that the request was created with the correct parameters
+    assert data == b"""<ReserveRequirementQuery MarketType="DAM"/>"""
+    verify_reserve_requirement_query(request, MarketType.DAY_AHEAD)
+
+
+def test_reserve_requirement_query_full():
+    """Test that the ReserveRequirementQuery class initializes and converts to XML as expected."""
+    # First, create a new reserve requirement query request
+    request = ReserveRequirementQuery(
+        market_type=MarketType.DAY_AHEAD,
+        area=AreaCode.TOKYO,
+    )
+
+    # Next, convert the request to XML
+    data = request.to_xml(skip_empty=True, encoding="utf-8")
+
+    # Finally, verify that the request was created with the correct parameters
+    assert data == b"""<ReserveRequirementQuery MarketType="DAM" Area="03"/>"""
+    verify_reserve_requirement_query(request, MarketType.DAY_AHEAD, AreaCode.TOKYO)
+
+
+def test_reserve_requirement_defaults():
+    """Test that the ReserveRequirement class initializes and converts to XML as expected."""
+    # First, create a new reserve requirement request
+    request = ReserveRequirement(
+        area=AreaCode.TOKYO,
+        requirements=[
+            Requirement(
+                start=DateTime(2024, 4, 12, 15),
+                end=DateTime(2024, 4, 12, 18),
+                direction=Direction.SELL,
+            ),
+        ],
+    )
+
+    # Next, convert the request to XML
+    data = request.to_xml(skip_empty=True, encoding="utf-8")
+
+    # Finally, verify that the request was created with the correct parameters
+    assert data == (
+        b"""<ReserveRequirement Area="03"><Requirement StartTime="2024-04-12T15:00:00" EndTime="2024-04-12T18:00:00" """
+        b"""Direction="1"/></ReserveRequirement>"""
+    )
+    verify_reserve_requirement(
+        request, AreaCode.TOKYO, [requirement_verifier(DateTime(2024, 4, 12, 15), DateTime(2024, 4, 12, 18))]
+    )
+
+
+def test_reserve_requirement_full():
+    """Test that the ReserveRequirement class initializes and converts to XML as expected."""
+    # First, create a new reserve requirement request
+    request = ReserveRequirement(
+        area=AreaCode.TOKYO,
+        requirements=[
+            Requirement(
+                start=DateTime(2024, 4, 12, 15),
+                end=DateTime(2024, 4, 12, 18),
+                direction=Direction.SELL,
+                primary_qty_kw=100,
+                secondary_1_qty_kw=200,
+                secondary_2_qty_kw=300,
+                tertiary_1_qty_kw=400,
+                tertiary_2_qty_kw=500,
+                primary_secondary_1_qty_kw=600,
+                primary_secondary_2_qty_kw=700,
+                primary_tertiary_1_qty_kw=800,
+            ),
+        ],
+    )
+
+    # Next, convert the request to XML
+    data = request.to_xml(skip_empty=True, encoding="utf-8")
+
+    # Finally, verify that the request was created with the correct parameters
+    assert data == read_request_file("reserve_requirement_full.xml", False)
+    verify_reserve_requirement(
+        request,
+        AreaCode.TOKYO,
+        [
+            requirement_verifier(
+                DateTime(2024, 4, 12, 15), DateTime(2024, 4, 12, 18), 100, 200, 300, 400, 500, 600, 700, 800
+            )
+        ],
+    )

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -40,6 +40,9 @@ from mms_client.types.offer import OfferStack
 from mms_client.types.registration import QueryAction
 from mms_client.types.registration import QueryType
 from mms_client.types.registration import RegistrationQuery
+from mms_client.types.reserve import Requirement
+from mms_client.types.reserve import ReserveRequirement
+from mms_client.types.reserve import ReserveRequirementQuery
 from mms_client.types.resource import AfcMinimumOutput
 from mms_client.types.resource import OutputBand
 from mms_client.types.resource import ResourceData
@@ -376,6 +379,50 @@ def verify_offer_cancel(req: OfferCancel, resource: str, start: DateTime, end: D
     assert req.start == start
     assert req.end == end
     assert req.market_type == market_type
+
+
+def verify_reserve_requirement_query(
+    req: ReserveRequirementQuery, market_type: MarketType, area: Optional[AreaCode] = None
+):
+    """Verify that the ReserveRequirementQuery was created with the correct parameters."""
+    assert req.area == area
+    assert req.market_type == market_type
+
+
+def verify_reserve_requirement(req: ReserveRequirement, area: AreaCode, requirement_verifiers: list):
+    """Verify that the ReserveRequirement was created with the correct parameters."""
+    assert req.area == area
+    verify_list(req.requirements, requirement_verifiers)
+
+
+def requirement_verifier(
+    start: DateTime,
+    end: DateTime,
+    primary: Optional[int] = None,
+    secondary_1: Optional[int] = None,
+    secondary_2: Optional[int] = None,
+    tertiary_1: Optional[int] = None,
+    tertiary_2: Optional[int] = None,
+    primary_secondary_1: Optional[int] = None,
+    primary_secondary_2: Optional[int] = None,
+    primary_tertiary_1: Optional[int] = None,
+):
+    """Verify that the given Requirement has the expected parameters."""
+
+    def inner(req: Requirement):
+        assert req.start == start
+        assert req.end == end
+        assert req.direction == Direction.SELL
+        assert req.primary_qty_kw == primary
+        assert req.secondary_1_qty_kw == secondary_1
+        assert req.secondary_2_qty_kw == secondary_2
+        assert req.tertiary_1_qty_kw == tertiary_1
+        assert req.tertiary_2_qty_kw == tertiary_2
+        assert req.primary_secondary_1_qty_kw == primary_secondary_1
+        assert req.primary_secondary_2_qty_kw == primary_secondary_2
+        assert req.primary_tertiary_1_qty_kw == primary_tertiary_1
+
+    return inner
 
 
 def verify_resource_data(


### PR DESCRIPTION
This PR adds a new method to the MMS client: `query_reserve_requirements` to allow the user to determine what their reserve requirements are for a given region and market.