### PR TITLE
Cu 8693z4817 plugin fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,10 @@ client = MmsClient(domain="mydomain.com", participant="F100", user="FAKEUSER", c
 ```
 
 ## Auditing XML Requests & Responses
-A common requirement for this sort of library is recording or saving the raw XML requests and responses for audit/logging purposes. This library supports this workflow through the `mms_client.utils.auditing.AuditPlugin` object. This object intercepts the XML request at the Zeep client level right before it is sent to the MMS and, similarly, intercepts the XML response immediately after it is received from the MMS. Before passing these objects on, without modifying them, it records the XML data as a byte string and passes it to two methods: `audit_request` and `audit_response`. These can be overridden by any object that inherits from this class, allowing the user to direct this data to whatever store they prefer to use for auditing or logging.
+A common requirement for this sort of library is recording or saving the raw XML requests and responses for audit/logging purposes. This library supports this workflow through the `mms_client.utils.plugin.Plugin` object. This object intercepts the XML request at the Zeep client level right before it is sent to the MMS and, similarly, intercepts the XML response immediately after it is received from the MMS. Before passing these objects on, without modifying them, it records the XML data as a byte string and passes it to two methods: `audit_request` and `audit_response`. These can be overridden by any object that inherits from this class, allowing the user to direct this data to whatever store they prefer to use for auditing or logging.
 
 ```python
-class TestAuditPlugin(AuditPlugin):
+class TestAuditPlugin(Plugin):
 
     def __init__(self):
         self.request = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mms_client"
-version = "v1.8.1"
+version = "v1.9.0"
 description = "API client for accessing the MMS"
 authors = ["Ryan Wood <ryan.wood@electroroute.co.jp>"]
 readme = "README.md"

--- a/src/mms_client/utils/multipart_transport.py
+++ b/src/mms_client/utils/multipart_transport.py
@@ -245,7 +245,7 @@ class MultipartTransport(Transport):
 
         # Attach each file to the multipart request
         for cid in files:
-            operation = self._operations[cid]
+            operation = self._operations.pop(cid)
             mtom_part.attach(self.create_attachment(cid))
 
         # Finally, create the final multipart request string
@@ -271,7 +271,7 @@ class MultipartTransport(Transport):
         Returns:    The attachment.
         """
         # First, get the attachment from the cache
-        attach = self._attachments[cid]
+        attach = self._attachments.pop(cid)
 
         # Next, create the attachment
         part = MIMEBase("application", "octet-stream")

--- a/src/mms_client/utils/plugin.py
+++ b/src/mms_client/utils/plugin.py
@@ -3,44 +3,44 @@
 from abc import ABC
 from abc import abstractmethod
 from logging import getLogger
-
-from lxml.etree import _Element as Element
-from lxml.etree import tostring
-from zeep import Plugin
-from zeep.wsdl.definitions import Operation
+from typing import Tuple
 
 # Set the default logger for the MMS client
 logger = getLogger(__name__)
 
 
-class AuditPlugin(ABC, Plugin):
+class Plugin(ABC):
     """Base class for audit plugins."""
 
-    def egress(self, envelope: Element, http_headers: dict, operation: Operation, binding_options):
+    def egress(self, message: bytes, http_headers: dict, operation: str) -> Tuple[bytes, dict]:
         """Handle the MMS request before it is sent.
 
-        Arguments are the same as in the egress method of the Plugin class.
+        Arguments:
+        message (bytes):        The message to send.
+        http_headers (dict):    The HTTP headers to send.
+        operation (str):        The operation being called.
 
         Returns:
         lxml.etree.Element: The XML message to send.
         dict:               The HTTP headers to send.
         """
-        data = tostring(envelope, encoding="UTF-8", xml_declaration=True)
-        self.audit_request(operation.name, data)
-        return envelope, http_headers
+        self.audit_request(operation, message)
+        return message, http_headers
 
-    def ingress(self, envelope: Element, http_headers: dict, operation: Operation):
+    def ingress(self, message: bytes, http_headers: dict, operation: str) -> Tuple[bytes, dict]:
         """Handle the MMS response before it is processed.
 
-        Arguments are the same as in the ingress method of the Plugin class.
+        Arguments:
+        message (bytes):        The message to process.
+        http_headers (dict):    The HTTP headers to process.
+        operation (str):        The operation being called.
 
         Returns:
         lxml.etree.Element: The XML message to process.
         dict:               The HTTP headers to process.
         """
-        data = tostring(envelope, encoding="UTF-8", xml_declaration=True)
-        self.audit_response(operation.name, data)
-        return envelope, http_headers
+        self.audit_response(operation, message)
+        return message, http_headers
 
     @abstractmethod
     def audit_request(self, operation: str, mms_request: bytes) -> None:

--- a/tests/test_utils/test_plugin.py
+++ b/tests/test_utils/test_plugin.py
@@ -1,7 +1,6 @@
 """Tests the functionality of the mms_client.utils.auditing module."""
 
 from base64 import b64encode
-from logging import getLogger
 
 import responses
 
@@ -10,7 +9,7 @@ from mms_client.types.transport import MmsRequest
 from mms_client.types.transport import RequestDataType
 from mms_client.types.transport import RequestType
 from mms_client.types.transport import ResponseDataType
-from mms_client.utils.auditing import AuditPlugin
+from mms_client.utils.plugin import Plugin
 from mms_client.utils.web import ClientType
 from mms_client.utils.web import Interface
 from mms_client.utils.web import ZWrapper
@@ -18,8 +17,8 @@ from tests.testutils import register_mms_request
 from tests.testutils import verify_mms_response
 
 
-class FakeAuditPlugin(AuditPlugin):
-    """Test AuditPlugin that we'll use to verify the functionality of the AuditPlugin class."""
+class FakeAuditPlugin(Plugin):
+    """Test Plugin that we'll use to verify the functionality of the Plugin class."""
 
     def __init__(self):
         """Initialize the TestAuditPlugin class."""
@@ -63,7 +62,7 @@ def test_auditer_works(mock_certificate: Certificate):
     verify_mms_response(resp, True, ResponseDataType.XML, b"derp")
     data = b64encode(b"derp").decode("UTF-8")
     assert auditor.request == (
-        """<?xml version='1.0' encoding='UTF-8'?>\n<soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/"""
+        """<?xml version='1.0' encoding='utf-8'?>\n<soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/"""
         """soap/envelope/"><soap-env:Body><ns0:RequestAttInfo xmlns:ns0="urn:abb.com:project/mms/types">"""
         """<requestType>mp.info</requestType><adminRole>false</adminRole><requestDataCompressed>false"""
         """</requestDataCompressed><requestDataType>XML</requestDataType><sendRequestDataOnSuccess>false"""
@@ -72,10 +71,10 @@ def test_auditer_works(mock_certificate: Certificate):
         """</soap-env:Body></soap-env:Envelope>"""
     ).encode("UTF-8")
     assert auditor.response == (
-        """<?xml version='1.0' encoding='UTF-8'?>\n<soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/"""
+        """<?xml version='1.0' encoding='utf-8'?>\n<soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/"""
         """soap/envelope/"><soap-env:Body><ns0:ResponseAttInfo xmlns:ns0="urn:abb.com:project/mms/types"><success>"""
         """true</success><warnings>false</warnings><responseBinary>false</responseBinary><responseCompressed>false"""
         f"""</responseCompressed><responseDataType>XML</responseDataType><responseData>{data}</responseData>"""
         """</ns0:ResponseAttInfo></soap-env:Body></soap-env:Envelope>"""
     ).encode("UTF-8")
-    assert auditor.name == "submitAttachment"
+    assert auditor.name == "https://www2.tdgc.jp/axis2/services/MiWebService"


### PR DESCRIPTION
This PR moves where the plugin is applied. Zeep plugins are applied before requests reach the transport layer, which is helpful for changing the XML structure but does nothing when multipart requests are being sent. As such, we have modified the code so that plugins are called inside the multipart transport.