### PR TITLE
Ensured that timezones work as expected

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mms_client"
-version = "v1.9.0"
+version = "v1.9.1"
 description = "API client for accessing the MMS"
 authors = ["Ryan Wood <ryan.wood@electroroute.co.jp>"]
 readme = "README.md"

--- a/src/mms_client/services/market.py
+++ b/src/mms_client/services/market.py
@@ -1,9 +1,10 @@
 """Contains the client layer for making market requests to the MMS server."""
 
-from datetime import date as Date
 from logging import getLogger
 from typing import List
 from typing import Optional
+
+from pydantic_extra_types.pendulum_dt import Date
 
 from mms_client.services.base import ClientProto
 from mms_client.services.base import ServiceConfiguration

--- a/src/mms_client/services/registration.py
+++ b/src/mms_client/services/registration.py
@@ -1,9 +1,10 @@
 """Contains the client layer for making registration requests to the MMS server."""
 
-from datetime import date as Date
 from logging import getLogger
 from typing import List
 from typing import Optional
+
+from pydantic_extra_types.pendulum_dt import Date
 
 from mms_client.services.base import ClientProto
 from mms_client.services.base import ServiceConfiguration

--- a/src/mms_client/types/award.py
+++ b/src/mms_client/types/award.py
@@ -5,6 +5,9 @@ from enum import Enum
 from typing import List
 from typing import Optional
 
+from pendulum import Timezone
+from pydantic import field_serializer
+from pydantic import field_validator
 from pydantic_core import PydanticUndefined
 from pydantic_extra_types.pendulum_dt import DateTime
 from pydantic_xml import attr
@@ -108,6 +111,16 @@ class AwardQuery(Payload, tag="AwardResultsQuery"):
     # Whether we are before gate close or after gate close. If this isn't provided, then all results will be retrieved
     # regardless of gate closure.
     gate_closed: Optional[BooleanFlag] = attr(default=None, name="AfterGC")
+
+    @field_serializer("start", "end")
+    def encode_datetime(self, value: DateTime) -> str:
+        """Encode the datetime to an MMS-compliant ISO 8601 string."""
+        return value.replace(tzinfo=None).isoformat()
+
+    @field_validator("start", "end")
+    def decode_datetime(self, value: DateTime) -> DateTime:
+        """Decode the datetime from an MMS-compliant ISO 8601 string."""
+        return value.replace(tzinfo=Timezone("Asia/Tokyo"))
 
 
 class Award(Payload):
@@ -286,6 +299,16 @@ class Award(Payload):
     # Whether we are before gate close or after gate close
     gate_closed: BooleanFlag = attr(name="AfterGC")
 
+    @field_serializer("submission_time")
+    def encode_datetime(self, value: DateTime) -> str:
+        """Encode the datetime to an MMS-compliant ISO 8601 string."""
+        return value.replace(tzinfo=None).isoformat() if value else ""
+
+    @field_validator("submission_time")
+    def decode_datetime(self, value: DateTime) -> DateTime:
+        """Decode the datetime from an MMS-compliant ISO 8601 string."""
+        return value.replace(tzinfo=Timezone("Asia/Tokyo"))
+
 
 class AwardResult(Payload, tag="AwardResults"):
     """Contains a number of bid rewards associated with a block of time and trade direction."""
@@ -301,6 +324,16 @@ class AwardResult(Payload, tag="AwardResults"):
 
     # The bid awards associated with these parameters
     data: List[Award] = element(tag="AwardResultsData", min_length=1)
+
+    @field_serializer("start", "end")
+    def encode_datetime(self, value: DateTime) -> str:
+        """Encode the datetime to an MMS-compliant ISO 8601 string."""
+        return value.replace(tzinfo=None).isoformat()
+
+    @field_validator("start", "end")
+    def decode_datetime(self, value: DateTime) -> DateTime:
+        """Decode the datetime from an MMS-compliant ISO 8601 string."""
+        return value.replace(tzinfo=Timezone("Asia/Tokyo"))
 
 
 class AwardResponse(AwardQuery, tag="AwardResultsQuery"):

--- a/src/mms_client/types/award.py
+++ b/src/mms_client/types/award.py
@@ -118,7 +118,7 @@ class AwardQuery(Payload, tag="AwardResultsQuery"):
         return value.replace(tzinfo=None).isoformat()
 
     @field_validator("start", "end")
-    def decode_datetime(self, value: DateTime) -> DateTime:
+    def decode_datetime(cls, value: DateTime) -> DateTime:  # pylint: disable=no-self-argument
         """Decode the datetime from an MMS-compliant ISO 8601 string."""
         return value.replace(tzinfo=Timezone("Asia/Tokyo"))
 
@@ -305,7 +305,7 @@ class Award(Payload):
         return value.replace(tzinfo=None).isoformat() if value else ""
 
     @field_validator("submission_time")
-    def decode_datetime(self, value: DateTime) -> DateTime:
+    def decode_datetime(cls, value: DateTime) -> DateTime:  # pylint: disable=no-self-argument
         """Decode the datetime from an MMS-compliant ISO 8601 string."""
         return value.replace(tzinfo=Timezone("Asia/Tokyo"))
 
@@ -331,7 +331,7 @@ class AwardResult(Payload, tag="AwardResults"):
         return value.replace(tzinfo=None).isoformat()
 
     @field_validator("start", "end")
-    def decode_datetime(self, value: DateTime) -> DateTime:
+    def decode_datetime(cls, value: DateTime) -> DateTime:  # pylint: disable=no-self-argument
         """Decode the datetime from an MMS-compliant ISO 8601 string."""
         return value.replace(tzinfo=Timezone("Asia/Tokyo"))
 

--- a/src/mms_client/types/market.py
+++ b/src/mms_client/types/market.py
@@ -1,11 +1,9 @@
 """Contains objects for market information."""
 
-# Have to use this becasue pydantic doesn't like pendulum.Date. I've submitted a PR to address this but it hasn't been
-# merged or released yet.
-from datetime import date as Date
 from enum import Enum
 from typing import Optional
 
+from pydantic_extra_types.pendulum_dt import Date
 from pydantic_xml import attr
 
 from mms_client.types.base import Envelope

--- a/src/mms_client/types/offer.py
+++ b/src/mms_client/types/offer.py
@@ -124,7 +124,7 @@ class OfferData(Payload):
         return value.replace(tzinfo=None).isoformat() if value else ""
 
     @field_validator("start", "end", "submission_time")
-    def decode_datetime(self, value: DateTime) -> DateTime:
+    def decode_datetime(cls, value: DateTime) -> DateTime:  # pylint: disable=no-self-argument
         """Decode the datetime from an MMS-compliant ISO 8601 string."""
         return value.replace(tzinfo=Timezone("Asia/Tokyo"))
 
@@ -151,7 +151,7 @@ class OfferCancel(Payload):
         return value.replace(tzinfo=None).isoformat()
 
     @field_validator("start", "end")
-    def decode_datetime(self, value: DateTime) -> DateTime:
+    def decode_datetime(cls, value: DateTime) -> DateTime:  # pylint: disable=no-self-argument
         """Decode the datetime from an MMS-compliant ISO 8601 string."""
         return value.replace(tzinfo=Timezone("Asia/Tokyo"))
 

--- a/src/mms_client/types/offer.py
+++ b/src/mms_client/types/offer.py
@@ -4,6 +4,9 @@ from decimal import Decimal
 from typing import List
 from typing import Optional
 
+from pendulum import Timezone
+from pydantic import field_serializer
+from pydantic import field_validator
 from pydantic_extra_types.pendulum_dt import DateTime
 from pydantic_xml import attr
 from pydantic_xml import element
@@ -115,6 +118,16 @@ class OfferData(Payload):
     # The date and time when the offer was submitted
     submission_time: Optional[DateTime] = attr(default=None, name="SubmissionTime")
 
+    @field_serializer("start", "end", "submission_time")
+    def encode_datetime(self, value: DateTime) -> str:
+        """Encode the datetime to an MMS-compliant ISO 8601 string."""
+        return value.replace(tzinfo=None).isoformat() if value else ""
+
+    @field_validator("start", "end", "submission_time")
+    def decode_datetime(self, value: DateTime) -> DateTime:
+        """Decode the datetime from an MMS-compliant ISO 8601 string."""
+        return value.replace(tzinfo=Timezone("Asia/Tokyo"))
+
 
 class OfferCancel(Payload):
     """Describes the data necessary to cancel an offer in the MMS."""
@@ -131,6 +144,16 @@ class OfferCancel(Payload):
 
     # The type of market for the offer was submitted on
     market_type: MarketType = attr(name="MarketType")
+
+    @field_serializer("start", "end")
+    def encode_datetime(self, value: DateTime) -> str:
+        """Encode the datetime to an MMS-compliant ISO 8601 string."""
+        return value.replace(tzinfo=None).isoformat()
+
+    @field_validator("start", "end")
+    def decode_datetime(self, value: DateTime) -> DateTime:
+        """Decode the datetime from an MMS-compliant ISO 8601 string."""
+        return value.replace(tzinfo=Timezone("Asia/Tokyo"))
 
 
 class OfferQuery(Payload):

--- a/src/mms_client/types/registration.py
+++ b/src/mms_client/types/registration.py
@@ -1,11 +1,9 @@
 """Contains objects for registrations."""
 
-# Have to use this becasue pydantic doesn't like pendulum.Date. I've submitted a PR to address this but it hasn't been
-# merged or released yet.
-from datetime import date as Date
 from enum import Enum
 from typing import Optional
 
+from pydantic_extra_types.pendulum_dt import Date
 from pydantic_xml import attr
 
 from mms_client.types.base import Envelope

--- a/src/mms_client/types/report.py
+++ b/src/mms_client/types/report.py
@@ -1,13 +1,16 @@
 """Contains objects for report data."""
 
-from datetime import date as Date
 from decimal import Decimal
 from enum import StrEnum
 from typing import Annotated
 from typing import List
 from typing import Optional
 
+from pendulum import Timezone as TZ
+from pydantic import field_serializer
+from pydantic import field_validator
 from pydantic_core import PydanticUndefined
+from pydantic_extra_types.pendulum_dt import Date
 from pydantic_extra_types.pendulum_dt import DateTime
 from pydantic_xml import BaseXmlModel
 from pydantic_xml import attr
@@ -330,6 +333,16 @@ class OutboundData(Envelope):
 
     # The time the report was published
     publish_time: Optional[DateTime] = attr(default=None, name="PublishTime")
+
+    @field_serializer("publish_time")
+    def encode_datetime(self, value: DateTime) -> str:
+        """Encode the datetime to an MMS-compliant ISO 8601 string."""
+        return value.replace(tzinfo=None).isoformat() if value else ""
+
+    @field_validator("publish_time")
+    def decode_datetime(self, value: DateTime) -> DateTime:
+        """Decode the datetime from an MMS-compliant ISO 8601 string."""
+        return value.replace(tzinfo=TZ("Asia/Tokyo"))
 
 
 class ReportLineBase(Payload):

--- a/src/mms_client/types/report.py
+++ b/src/mms_client/types/report.py
@@ -340,7 +340,7 @@ class OutboundData(Envelope):
         return value.replace(tzinfo=None).isoformat() if value else ""
 
     @field_validator("publish_time")
-    def decode_datetime(self, value: DateTime) -> DateTime:
+    def decode_datetime(cls, value: DateTime) -> DateTime:  # pylint: disable=no-self-argument
         """Decode the datetime from an MMS-compliant ISO 8601 string."""
         return value.replace(tzinfo=TZ("Asia/Tokyo"))
 

--- a/src/mms_client/types/reserve.py
+++ b/src/mms_client/types/reserve.py
@@ -3,6 +3,9 @@
 from typing import List
 from typing import Optional
 
+from pendulum import Timezone
+from pydantic import field_serializer
+from pydantic import field_validator
 from pydantic_extra_types.pendulum_dt import DateTime
 from pydantic_xml import attr
 from pydantic_xml import element
@@ -49,6 +52,16 @@ class Requirement(Payload):
 
     # The minimum reserve of compound primary and tertiary 1 in kW
     primary_tertiary_1_qty_kw: Optional[int] = power_positive("CompoundPriTer1ReserveQuantityInKw", True)
+
+    @field_serializer("start", "end")
+    def encode_datetime(self, value: DateTime) -> str:
+        """Encode the datetime to an MMS-compliant ISO 8601 string."""
+        return value.replace(tzinfo=None).isoformat()
+
+    @field_validator("start", "end")
+    def decode_datetime(self, value: DateTime) -> DateTime:
+        """Decode the datetime from an MMS-compliant ISO 8601 string."""
+        return value.replace(tzinfo=Timezone("Asia/Tokyo"))
 
 
 class ReserveRequirement(Payload):

--- a/src/mms_client/types/reserve.py
+++ b/src/mms_client/types/reserve.py
@@ -59,7 +59,7 @@ class Requirement(Payload):
         return value.replace(tzinfo=None).isoformat()
 
     @field_validator("start", "end")
-    def decode_datetime(self, value: DateTime) -> DateTime:
+    def decode_datetime(cls, value: DateTime) -> DateTime:  # pylint: disable=no-self-argument
         """Decode the datetime from an MMS-compliant ISO 8601 string."""
         return value.replace(tzinfo=Timezone("Asia/Tokyo"))
 

--- a/src/mms_client/types/resource.py
+++ b/src/mms_client/types/resource.py
@@ -2,7 +2,6 @@
 
 # pylint: disable=too-many-lines
 
-from datetime import date as Date
 from decimal import Decimal
 from enum import Enum
 from typing import Annotated
@@ -10,6 +9,7 @@ from typing import List
 from typing import Optional
 
 from pydantic_core import PydanticUndefined
+from pydantic_extra_types.pendulum_dt import Date
 from pydantic_xml import attr
 from pydantic_xml import element
 from pydantic_xml import wrapped

--- a/tests/test_client/test_base.py
+++ b/tests/test_client/test_base.py
@@ -1,9 +1,8 @@
 """Tests the functionality of the mms_client.services.base module."""
 
-from datetime import date as Date
-
 import pytest
 import responses
+from pendulum import Date
 from pendulum import DateTime
 
 from mms_client.services.base import BaseClient

--- a/tests/test_client/test_market.py
+++ b/tests/test_client/test_market.py
@@ -1,10 +1,10 @@
 """Tests the functionality in the mms_client.services.market module."""
 
-from datetime import date as Date
 from decimal import Decimal
 
 import pytest
 import responses
+from pendulum import Date
 from pendulum import DateTime
 from pendulum import Timezone
 
@@ -80,8 +80,8 @@ def test_query_reserve_requirements_works(mock_certificate):
         AreaCode.TOKYO,
         [
             requirement_verifier(
-                DateTime(2024, 4, 12, 15, tzinfo=Timezone("UTC")),
-                DateTime(2024, 4, 12, 18, tzinfo=Timezone("UTC")),
+                DateTime(2024, 4, 12, 15, tzinfo=Timezone("Asia/Tokyo")),
+                DateTime(2024, 4, 12, 18, tzinfo=Timezone("Asia/Tokyo")),
                 100,
                 200,
                 300,
@@ -158,8 +158,8 @@ def test_put_offer_works(mock_certificate):
         offer,
         [offer_stack_verifier(1, 100, 100, id="FAKE_ID")],
         "FAKE_RESO",
-        DateTime(2024, 3, 15, 12, tzinfo=Timezone("UTC")),
-        DateTime(2024, 3, 15, 21, tzinfo=Timezone("UTC")),
+        DateTime(2024, 3, 15, 12, tzinfo=Timezone("Asia/Tokyo")),
+        DateTime(2024, 3, 15, 21, tzinfo=Timezone("Asia/Tokyo")),
         Direction.SELL,
         pattern=1,
         bsp_participant="F100",
@@ -168,7 +168,7 @@ def test_put_offer_works(mock_certificate):
         area=AreaCode.CHUBU,
         resource_short_name="偽電力",
         system_code="FSYS0",
-        submission_time=DateTime(2024, 3, 15, 11, 44, 15, tzinfo=Timezone("UTC")),
+        submission_time=DateTime(2024, 3, 15, 11, 44, 15, tzinfo=Timezone("Asia/Tokyo")),
     )
 
 
@@ -236,8 +236,8 @@ def test_put_offers_works(mock_certificate):
         offers[0],
         [offer_stack_verifier(1, 100, 100, id="FAKE_ID")],
         "FAKE_RESO",
-        DateTime(2024, 3, 15, 12, tzinfo=Timezone("UTC")),
-        DateTime(2024, 3, 15, 21, tzinfo=Timezone("UTC")),
+        DateTime(2024, 3, 15, 12, tzinfo=Timezone("Asia/Tokyo")),
+        DateTime(2024, 3, 15, 21, tzinfo=Timezone("Asia/Tokyo")),
         Direction.SELL,
         pattern=1,
         bsp_participant="F100",
@@ -246,7 +246,7 @@ def test_put_offers_works(mock_certificate):
         area=AreaCode.CHUBU,
         resource_short_name="偽電力",
         system_code="FSYS0",
-        submission_time=DateTime(2024, 3, 15, 11, 44, 15, tzinfo=Timezone("UTC")),
+        submission_time=DateTime(2024, 3, 15, 11, 44, 15, tzinfo=Timezone("Asia/Tokyo")),
     )
 
 
@@ -286,8 +286,8 @@ def test_query_offers_works(mock_certificate):
         offers[0],
         [offer_stack_verifier(1, 100, 100, id="FAKE_ID")],
         "FAKE_RESO",
-        DateTime(2024, 3, 15, 12, tzinfo=Timezone("UTC")),
-        DateTime(2024, 3, 15, 21, tzinfo=Timezone("UTC")),
+        DateTime(2024, 3, 15, 12, tzinfo=Timezone("Asia/Tokyo")),
+        DateTime(2024, 3, 15, 21, tzinfo=Timezone("Asia/Tokyo")),
         Direction.SELL,
         pattern=1,
         bsp_participant="F100",
@@ -296,7 +296,7 @@ def test_query_offers_works(mock_certificate):
         area=AreaCode.CHUBU,
         resource_short_name="偽電力",
         system_code="FSYS0",
-        submission_time=DateTime(2024, 3, 15, 11, 44, 15, tzinfo=Timezone("UTC")),
+        submission_time=DateTime(2024, 3, 15, 11, 44, 15, tzinfo=Timezone("Asia/Tokyo")),
     )
 
 
@@ -362,8 +362,8 @@ def test_cancel_offer_works(mock_certificate):
     verify_offer_cancel(
         resp,
         "FAKE_RESO",
-        DateTime(2024, 3, 15, 12, tzinfo=Timezone("UTC")),
-        DateTime(2024, 3, 15, 21, tzinfo=Timezone("UTC")),
+        DateTime(2024, 3, 15, 12, tzinfo=Timezone("Asia/Tokyo")),
+        DateTime(2024, 3, 15, 21, tzinfo=Timezone("Asia/Tokyo")),
         MarketType.DAY_AHEAD,
     )
 
@@ -389,13 +389,7 @@ def test_query_awards_works(mock_certificate):
     register_mms_request(
         RequestType.MARKET,
         (
-            "BiEsp0K4TkHJv0NbYf82KOyn8bhkEQxX3QlOq5lLYQxzPOdonKDuy/E8huI6PgzX+Md5MckH2WRf14+eKpvJLtc8o9bDbcF+YkSxWr147"
-            "jj7x28ScDJT4dMdOgMNzvCY2N66a9JD2TSZYEfgmFEy+Aez9KIXMHyiBva+wrQ13WLLyXambGZ3oZsOYK6U5qhgO842HPQu+LlCfory7w"
-            "iTIOklUop5BxVnT9SDlwRuXv3hUEO3TqnjT8d2nvtuBeAcKMyHD4F83VOF8t0PRZz6haacOOqOBf5nzij5oA5JUdQaCPN2KLx0i0hqbe5"
-            "L7q8+15D267UY2L5Pd2pfgNoT/8KUE4Rhgdzdsp7m7uQTWpt2xxNjvx/cdV27zRtIk6g57udT034QTtGct8s0+cX+2wMolh7hegPIoh4d"
-            "oyUJFdSXdMtia3sRnD5HGREafaT3pFqH66NJp9/iu65stSIBSPMRdElCIlm/LBy3aA6fj1mhbUTWcPLOWvF4bDNbLEZuzPltnpZOhJo9I"
-            "uhP3q+o2ZJceJmyyXO4ikuO6Rf/QSXLWl2DocvstfGfWjWmYWP9pgOhvxLWQw9XRksygEgXs0OmgeQW4NyB6NcpgVTdNX3Yj+qh9nUYVh"
-            "/T43icqzkZTBcIPkpchMNe5Ms4l0r16WHhHdNKOYmfDGsP/KRk3js="
+            "8JZ4ecLOMVtm30sjaxVsk6WL/A08yhDsidfgX4tYenxZeLyN0TDC8RTQVUNBlOc6zXP4eE6rYXu4SJ2OBTMdbVud8CrC0Yy9uD+R40gZ+HSfLf5bDPjdHXMrFbXBhA8pY5J5HFs3zhMZNuhGyUtvTqPbs6q6nWkuXdPqyftO/MX4ZjCqq3R3ZFpldM5lS5dLYRFX/CEQ9mnxISM9cQUbqeVawQZNo+PsFOylG91jGNlw4ZL7CDEC+BFqJk7BL8l5b3cCvTwGknFg4IM55MzYQgtfnisn73cN69a1LJbabAOr2NFuj98n8PaLhpxledwyVM3gN4oCFlA8SnzviMY/iPAzN81pxHg69aUJAJbLyqwmUqPb7/E/qiC6dY9ty/8eFdvoN+APFYAnY8sWQyQUENFBas8Osij9i50J2n/x3muQ8zzcmWIXW+mmp0KnxzyO/HKPqxoadfqAPQgzhh/4KyGZxa6jhYYV6rfs7BwiJH47pSQ+AXPasOJOdwMK4K9a8yQoEQloaxr/dLcwPWFccsShXFtMSZxCRVl2tJA0KtK7B1n6LXf3YkmqHS0tfUb7dh2dpXbQCfSGRaZgzAd5DZrYh5XTX99Up38m+qeESsxMmHzBnA5UED6n77yP7ufN4j5P2mCOwrVf0mxJJUa/b2gtJT5xKTRN30kzfrYrSFc="
         ),
         read_request_file("query_awards_request.xml"),
         read_file("query_awards_response.xml"),

--- a/tests/test_client/test_registration.py
+++ b/tests/test_client/test_registration.py
@@ -1,10 +1,10 @@
 """Tests the functionality in the mms_client.services.registration module."""
 
-from datetime import date as Date
 from decimal import Decimal
 
 import pytest
 import responses
+from pendulum import Date
 
 from mms_client.client import MmsClient
 from mms_client.types.enums import AreaCode

--- a/tests/test_client/test_report.py
+++ b/tests/test_client/test_report.py
@@ -1,10 +1,10 @@
 """Tests the functionality in the mms_client.services.report module."""
 
-from datetime import date as Date
 from decimal import Decimal
 
 import pytest
 import responses
+from pendulum import Date
 
 from mms_client.client import MmsClient
 from mms_client.types.enums import AreaCode

--- a/tests/test_files/awards_response_full.xml
+++ b/tests/test_files/awards_response_full.xml
@@ -1,6 +1,6 @@
-<AwardResultsQuery MarketType="DAM" Area="03" LinkedArea="02" ResourceName="FAKE_RESO" StartTime="2024-04-12T15:00:00+09:00" EndTime="2024-04-12T18:00:00+09:00" AfterGC="1">
+<AwardResultsQuery MarketType="DAM" Area="03" LinkedArea="02" ResourceName="FAKE_RESO" StartTime="2024-04-12T15:00:00" EndTime="2024-04-12T18:00:00" AfterGC="1">
     <AwardResultsQueryResponse>
-        <AwardResults StartTime="2024-04-12T15:00:00+09:00" EndTime="2024-04-12T18:00:00+09:00" Direction="1">
+        <AwardResults StartTime="2024-04-12T15:00:00" EndTime="2024-04-12T18:00:00" Direction="1">
             <AwardResultsData
                  ContractId="156098uqt3qawldefjT"
                  JbmsId="4235230998"
@@ -48,7 +48,7 @@
                  Tertiary1InvalidQuantityInKw="4004"
                  BaselineLoadFileNameNeg="W9_3010_20240411_15_AS490_FAKE_NEG.xml"
                  BaselineLoadFileNamePos="W9_3010_20240411_15_AS490_FAKE_POS.xml"
-                 SubmissionTime="2024-04-10T22:34:44+09:00"
+                 SubmissionTime="2024-04-10T22:34:44"
                  OfferAwardedLevel="2"
                  OfferId="FAKE_ID"
                  ContractSource="2"

--- a/tests/test_files/download_report_response_full.xml
+++ b/tests/test_files/download_report_response_full.xml
@@ -1,4 +1,4 @@
-<OutboundData DatasetName="BSP_ResourceList" DatasetType="ON_DEMAND" Date="2024-04-12" DateType="TRADE" DateTimeIndicator="JST" PublishTime="2024-04-12T15:00:00+09:00">
+<OutboundData DatasetName="BSP_ResourceList" DatasetType="ON_DEMAND" Date="2024-04-12" DateType="TRADE" DateTimeIndicator="JST" PublishTime="2024-04-12T15:00:00">
     <BSP_ResourceList
          ROW="1"
          ParticipantName="F100"

--- a/tests/test_files/query_awards_request.xml
+++ b/tests/test_files/query_awards_request.xml
@@ -1,5 +1,5 @@
 <MarketData>
     <MarketQuery Date="2024-04-12" NumOfDays="1" ParticipantName="F100" UserName="FAKEUSER">
-        <AwardResultsQuery AfterGC="1" Area="03" EndTime="2024-04-12T18:00:00+09:00" LinkedArea="02" MarketType="DAM" ResourceName="FAKE_RESO" StartTime="2024-04-12T15:00:00+09:00"></AwardResultsQuery>
+        <AwardResultsQuery AfterGC="1" Area="03" EndTime="2024-04-12T18:00:00" LinkedArea="02" MarketType="DAM" ResourceName="FAKE_RESO" StartTime="2024-04-12T15:00:00"></AwardResultsQuery>
     </MarketQuery>
 </MarketData>

--- a/tests/test_files/query_awards_response.xml
+++ b/tests/test_files/query_awards_response.xml
@@ -14,7 +14,7 @@
             <Information Code="Info1" />
             <Information Code="Info2" />
         </Messages>
-        <AwardResultsQuery MarketType="DAM" Area="03" LinkedArea="02" ResourceName="FAKE_RESO" StartTime="2024-04-12T15:00:00+09:00" EndTime="2024-04-12T18:00:00+09:00" AfterGC="1" Validation="PASSED" Success="true">
+        <AwardResultsQuery MarketType="DAM" Area="03" LinkedArea="02" ResourceName="FAKE_RESO" StartTime="2024-04-12T15:00:00" EndTime="2024-04-12T18:00:00" AfterGC="1" Validation="PASSED" Success="true">
             <Messages>
                 <Warning Code="Warning1" />
                 <Warning Code="Warning2" />
@@ -28,7 +28,7 @@
                     <Information Code="Info1" />
                     <Information Code="Info2" />
                 </Messages>
-                <AwardResults StartTime="2024-04-12T15:00:00+09:00" EndTime="2024-04-12T18:00:00+09:00" Direction="1">
+                <AwardResults StartTime="2024-04-12T15:00:00" EndTime="2024-04-12T18:00:00" Direction="1">
                     <Messages>
                         <Warning Code="Warning1" />
                         <Warning Code="Warning2" />
@@ -82,7 +82,7 @@
                         Tertiary1InvalidQuantityInKw="4004"
                         BaselineLoadFileNameNeg="W9_3010_20240411_15_AS490_FAKE_NEG.xml"
                         BaselineLoadFileNamePos="W9_3010_20240411_15_AS490_FAKE_POS.xml"
-                        SubmissionTime="2024-04-10T22:34:44+09:00"
+                        SubmissionTime="2024-04-10T22:34:44"
                         OfferAwardedLevel="2"
                         OfferId="FAKE_ID"
                         ContractSource="2"

--- a/tests/test_types/test_award.py
+++ b/tests/test_types/test_award.py
@@ -39,8 +39,7 @@ def test_award_results_query_defaults():
 
     # Finally, verify that the request was created with the correct parameters
     assert data == (
-        b"""<AwardResultsQuery MarketType="DAM" StartTime="2024-04-12T15:00:00+09:00" """
-        b"""EndTime="2024-04-12T18:00:00+09:00"/>"""
+        b"""<AwardResultsQuery MarketType="DAM" StartTime="2024-04-12T15:00:00" EndTime="2024-04-12T18:00:00"/>"""
     )
     verify_award_query(
         request,
@@ -69,7 +68,7 @@ def test_award_results_query_full():
     # Finally, verify that the request was created with the correct parameters
     assert data == (
         b"""<AwardResultsQuery MarketType="DAM" Area="03" LinkedArea="02" ResourceName="FAKE_RESO" """
-        b"""StartTime="2024-04-12T15:00:00+09:00" EndTime="2024-04-12T18:00:00+09:00" AfterGC="1"/>"""
+        b"""StartTime="2024-04-12T15:00:00" EndTime="2024-04-12T18:00:00" AfterGC="1"/>"""
     )
     verify_award_query(
         request,
@@ -97,8 +96,7 @@ def test_award_results_response_defaults():
 
     # Finally, verify that the response was created with the correct parameters
     assert data == (
-        b"""<AwardResultsQuery MarketType="DAM" StartTime="2024-04-12T15:00:00+09:00" """
-        b"""EndTime="2024-04-12T18:00:00+09:00"/>"""
+        b"""<AwardResultsQuery MarketType="DAM" StartTime="2024-04-12T15:00:00" EndTime="2024-04-12T18:00:00"/>"""
     )
     verify_award_response(
         response,

--- a/tests/test_types/test_market.py
+++ b/tests/test_types/test_market.py
@@ -1,6 +1,6 @@
 """Tests the functionality in the mms_client.types.market module."""
 
-from datetime import date as Date
+from pendulum import Date
 
 from mms_client.types.market import MarketCancel
 from mms_client.types.market import MarketQuery

--- a/tests/test_types/test_offer.py
+++ b/tests/test_types/test_offer.py
@@ -1,6 +1,7 @@
 """Tests the functionality in the mms_client.types.offer module."""
 
 from pendulum import DateTime
+from pendulum import Timezone
 
 from mms_client.types.enums import AreaCode
 from mms_client.types.market import MarketType
@@ -34,8 +35,8 @@ def test_offer_submit_defaults():
         request,
         [offer_stack_verifier(1, 100, 100)],
         "FAKE_RESO",
-        DateTime(2019, 8, 30, 3, 24, 15),
-        DateTime(2019, 9, 30, 3, 24, 15),
+        DateTime(2019, 8, 30, 3, 24, 15, tzinfo=Timezone("Asia/Tokyo")),
+        DateTime(2019, 9, 30, 3, 24, 15, tzinfo=Timezone("Asia/Tokyo")),
         Direction.SELL,
     )
     assert (
@@ -83,8 +84,8 @@ def test_offer_submit_full():
         request,
         [offer_stack_verifier(1, 100, 100, 150, 200, 250, 300, 350, "FAKE_ID")],
         "FAKE_RESO",
-        DateTime(2019, 8, 30, 3, 24, 15),
-        DateTime(2019, 9, 30, 3, 24, 15),
+        DateTime(2019, 8, 30, 3, 24, 15, tzinfo=Timezone("Asia/Tokyo")),
+        DateTime(2019, 9, 30, 3, 24, 15, tzinfo=Timezone("Asia/Tokyo")),
         Direction.SELL,
         12,
         "F100",
@@ -93,7 +94,7 @@ def test_offer_submit_full():
         AreaCode.CHUBU,
         "偽電力",
         "FSYS0",
-        DateTime(2019, 8, 30, 3, 24, 15),
+        DateTime(2019, 8, 30, 3, 24, 15, tzinfo=Timezone("Asia/Tokyo")),
     )
     assert data == (
         """<OfferData ResourceName="FAKE_RESO" StartTime="2019-08-30T03:24:15" EndTime="2019-09-30T03:24:15" """
@@ -120,7 +121,11 @@ def test_offer_cancel():
 
     # Finally, verify that the request was created with the correct parameters
     verify_offer_cancel(
-        request, "FAKE_RESO", DateTime(2019, 8, 30, 3, 24, 15), DateTime(2019, 9, 30, 3, 24, 15), MarketType.WEEK_AHEAD
+        request,
+        "FAKE_RESO",
+        DateTime(2019, 8, 30, 3, 24, 15, tzinfo=Timezone("Asia/Tokyo")),
+        DateTime(2019, 9, 30, 3, 24, 15, tzinfo=Timezone("Asia/Tokyo")),
+        MarketType.WEEK_AHEAD,
     )
     assert data == (
         b"""<OfferCancel ResourceName="FAKE_RESO" StartTime="2019-08-30T03:24:15" EndTime="2019-09-30T03:24:15" """

--- a/tests/test_types/test_registration.py
+++ b/tests/test_types/test_registration.py
@@ -1,6 +1,6 @@
 """Tests the functionality in the mms_client.types.registration module."""
 
-from datetime import date as Date
+from pendulum import Date
 
 from mms_client.types.registration import QueryAction
 from mms_client.types.registration import QueryType

--- a/tests/test_types/test_report.py
+++ b/tests/test_types/test_report.py
@@ -3,6 +3,7 @@
 from decimal import Decimal
 
 from pendulum import DateTime
+from pendulum import Timezone as TZ
 
 from mms_client.types.enums import AreaCode
 from mms_client.types.enums import BaseLineSettingMethod
@@ -280,7 +281,7 @@ def test_outbound_data():
         ReportName.BSP_RESOURCE_LIST,
         Periodicity.ON_DEMAND,
         Date(2024, 4, 12),
-        DateTime(2024, 4, 12, 15),
+        DateTime(2024, 4, 12, 15, tzinfo=TZ("Asia/Tokyo")),
     )
 
 

--- a/tests/test_types/test_reserve.py
+++ b/tests/test_types/test_reserve.py
@@ -1,6 +1,7 @@
 """Tests the functionality in the mms_client.types.reserve module."""
 
-from pydantic_extra_types.pendulum_dt import DateTime
+from pendulum import DateTime
+from pendulum import Timezone
 
 from mms_client.types.enums import AreaCode
 from mms_client.types.enums import Direction
@@ -68,7 +69,14 @@ def test_reserve_requirement_defaults():
         b"""Direction="1"/></ReserveRequirement>"""
     )
     verify_reserve_requirement(
-        request, AreaCode.TOKYO, [requirement_verifier(DateTime(2024, 4, 12, 15), DateTime(2024, 4, 12, 18))]
+        request,
+        AreaCode.TOKYO,
+        [
+            requirement_verifier(
+                DateTime(2024, 4, 12, 15, tzinfo=Timezone("Asia/Tokyo")),
+                DateTime(2024, 4, 12, 18, tzinfo=Timezone("Asia/Tokyo")),
+            )
+        ],
     )
 
 
@@ -104,7 +112,16 @@ def test_reserve_requirement_full():
         AreaCode.TOKYO,
         [
             requirement_verifier(
-                DateTime(2024, 4, 12, 15), DateTime(2024, 4, 12, 18), 100, 200, 300, 400, 500, 600, 700, 800
+                DateTime(2024, 4, 12, 15, tzinfo=Timezone("Asia/Tokyo")),
+                DateTime(2024, 4, 12, 18, tzinfo=Timezone("Asia/Tokyo")),
+                100,
+                200,
+                300,
+                400,
+                500,
+                600,
+                700,
+                800,
             )
         ],
     )

--- a/tests/test_types/test_resource.py
+++ b/tests/test_types/test_resource.py
@@ -1,7 +1,8 @@
 """Tests the functionality in the mms_client.types.resource module."""
 
-from datetime import date as Date
 from decimal import Decimal
+
+from pendulum import Date
 
 from mms_client.types.enums import AreaCode
 from mms_client.types.resource import AfcMinimumOutput

--- a/tests/test_utils/test_serialization.py
+++ b/tests/test_utils/test_serialization.py
@@ -1,8 +1,7 @@
 """Tests the functionality in the mms_client.utils.serialization module."""
 
-from datetime import date as Date
-
 import pytest
+from pendulum import Date
 from pendulum import DateTime
 from pendulum import Timezone
 
@@ -216,8 +215,8 @@ def test_deserialize_works():
         resp.data,
         [offer_stack_verifier(1, 100, 100, 150, 200, 250, 300, 350, "FAKE_ID")],
         "FAKE_RESO",
-        DateTime(2019, 8, 30, 3, 24, 15, tzinfo=Timezone("UTC")),
-        DateTime(2019, 8, 30, 11, 24, 15, tzinfo=Timezone("UTC")),
+        DateTime(2019, 8, 30, 3, 24, 15, tzinfo=Timezone("Asia/Tokyo")),
+        DateTime(2019, 8, 30, 11, 24, 15, tzinfo=Timezone("Asia/Tokyo")),
         Direction.SELL,
         12,
         "F100",
@@ -226,7 +225,7 @@ def test_deserialize_works():
         AreaCode.CHUBU,
         "偽電力",
         "FSYS0",
-        DateTime(2019, 8, 29, 3, 24, 15, tzinfo=Timezone("UTC")),
+        DateTime(2019, 8, 29, 3, 24, 15, tzinfo=Timezone("Asia/Tokyo")),
     )
     verify_response_common(resp.payload.data_validation, True, ValidationStatus.PASSED)
     verify_market_submit(resp.envelope, Date(2019, 8, 29), "F100", "FAKEUSER", MarketType.DAY_AHEAD, 1)
@@ -389,8 +388,8 @@ def test_deserialize_multi_works():
         resp.data[0],
         [offer_stack_verifier(1, 100, 100, 150, 200, 250, 300, 350, "FAKE_ID")],
         "FAKE_RESO",
-        DateTime(2019, 8, 30, 3, 24, 15, tzinfo=Timezone("UTC")),
-        DateTime(2019, 8, 30, 11, 24, 15, tzinfo=Timezone("UTC")),
+        DateTime(2019, 8, 30, 3, 24, 15, tzinfo=Timezone("Asia/Tokyo")),
+        DateTime(2019, 8, 30, 11, 24, 15, tzinfo=Timezone("Asia/Tokyo")),
         Direction.SELL,
         12,
         "F100",
@@ -399,7 +398,7 @@ def test_deserialize_multi_works():
         AreaCode.CHUBU,
         "偽電力",
         "FSYS0",
-        DateTime(2019, 8, 29, 3, 24, 15, tzinfo=Timezone("UTC")),
+        DateTime(2019, 8, 29, 3, 24, 15, tzinfo=Timezone("Asia/Tokyo")),
     )
     verify_response_common(resp.payload[0].data_validation, True, ValidationStatus.PASSED)
     verify_market_submit(resp.envelope, Date(2019, 8, 29), "F100", "FAKEUSER", MarketType.DAY_AHEAD, 1)


### PR DESCRIPTION
This PR fixes all `DateTime` objects in the repository so that they are sent to the MMS in ISO-format without a time zone and are received in GMT+9 (Asia/Tokyo). This means that this package will assume that all `DateTime` objects are in GMT+9 going forward. Any dates should be converted beforehand.

Note that, although we could convert to GMT+9 (Asia/Tokyo) before stripping the time zone out, this would mean that all naive code would be broken, which is not what we want here.