### PR TITLE
Make the reserve requirements endpoint return a list instead of a sin…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mms_client"
-version = "v1.9.1"
+version = "v1.9.2"
 description = "API client for accessing the MMS"
 authors = ["Ryan Wood <ryan.wood@electroroute.co.jp>"]
 readme = "README.md"

--- a/src/mms_client/services/market.py
+++ b/src/mms_client/services/market.py
@@ -37,7 +37,7 @@ class MarketClientMixin:  # pylint: disable=unused-argument
     # The configuration for the market service
     config = ServiceConfiguration(Interface.MI, Serializer(SchemaType.MARKET, "MarketData"))
 
-    @mms_endpoint(
+    @mms_multi_endpoint(
         name="MarketQuery_ReserveRequirementQuery",
         service=config,
         request_type=RequestType.INFO,

--- a/tests/test_client/test_market.py
+++ b/tests/test_client/test_market.py
@@ -75,8 +75,9 @@ def test_query_reserve_requirements_works(mock_certificate):
     resp = client.query_reserve_requirements(request, 1, Date(2024, 4, 12))
 
     # Finally, verify the response
+    assert len(resp) == 1
     verify_reserve_requirement(
-        resp,
+        resp[0],
         AreaCode.TOKYO,
         [
             requirement_verifier(


### PR DESCRIPTION
This PR fixes an issue where the `query_reserve_requirements` endpoint was only returning a single reserve requirement rather than a list of reserve requirements.