### PR TITLE
Have to make their XSD not be breaking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mms_client"
-version = "v1.11.0"
+version = "v1.11.1"
 description = "API client for accessing the MMS"
 authors = ["Ryan Wood <ryan.wood@electroroute.co.jp>"]
 readme = "README.md"

--- a/src/mms_client/schemas/xsd/mi-market.xsd
+++ b/src/mms_client/schemas/xsd/mi-market.xsd
@@ -1600,8 +1600,8 @@
       <xs:attribute name="CommandOperationMethodSec2Ter1Ter2" type="CommandOperationMethodSec2Ter1Ter2Type" use="optional"/>
       <xs:attribute name="OfferPrice" type="PriceValue6.2RoundedType" use="required"/>
       <xs:attribute name="ContractPrice" type="PriceValue6.2RoundedType" use="required"/>
-      <xs:attribute name="RampDownUnitPrice" type="PriceValue6.2RoundedType" use="required"/>
-      <xs:attribute name="StartUpUnitPrice" type="PriceValue6.2RoundedType" use="required"/>
+      <xs:attribute name="RampDownUnitPrice" type="PriceValue6.2RoundedType" use="optional"/>
+      <xs:attribute name="StartUpUnitPrice" type="PriceValue6.2RoundedType" use="optional"/>
       <xs:attribute name="PerfEvalCoeff" type="PosValue4.2RoundedType" use="required"/>
       <xs:attribute name="CorrectedUnitPrice" type="PriceValue8.2RoundedType" use="required"/>
       <xs:attribute name="SubRequirementType" type="SubRequirementTypeType" use="optional"/>

--- a/tests/test_files/awards_response_real.xml
+++ b/tests/test_files/awards_response_real.xml
@@ -1,0 +1,34 @@
+<AwardResultsQuery MarketType="DAM" Area="03" LinkedArea="02" ResourceName="FAKE_RESO" StartTime="2024-04-12T15:00:00" EndTime="2024-04-12T18:00:00" AfterGC="1">
+    <AwardResultsQueryResponse>
+        <AwardResults StartTime="2024-04-12T15:00:00" EndTime="2024-04-12T18:00:00" Direction="1">
+            <AwardResultsData
+                 ContractId="156098uqt3qawldefjT"
+                 JbmsId="4235230998"
+                 Area="03"
+                 LinkedArea="02"
+                 ResourceName="FAKE_RESO"
+                 ResourceShortName="偽電力"
+                 SystemCode="FSYS0"
+                 ResourceType="01"
+                 DrPatternNumber="2"
+                 DrPatternName="偽パターン"
+                 BspParticipantName="F100"
+                 CompanyShortName="偽会社"
+                 OperatorCode="FAKE"
+                 CommandOperationMethodPriSec1="3"
+                 CommandOperationMethodSec2Ter1Ter2="2"
+                 OfferPrice="42.15"
+                 ContractPrice="69.44"
+                 PerfEvalCoeff="35.79"
+                 CorrectedUnitPrice="199.99"
+                 Tertiary2OfferQuantityInKw="9000"
+                 Tertiary2AwardQuantityInKw="5004"
+                 Tertiary2ContractQuantityInKw="1000"
+                 SubmissionTime="2024-04-10T22:34:44"
+                 OfferAwardedLevel="2"
+                 OfferId="FAKE_ID"
+                 ContractSource="2"
+                 AfterGC="1"/>
+        </AwardResults>
+    </AwardResultsQueryResponse>
+</AwardResultsQuery>


### PR DESCRIPTION
This PR includes an emergency fix to the XSD schema used by the MMS to ensure that bid awards don't break on deserialization. The `StartUpUnitPrice` and `RampDownUnitPrice` fields are not yet included in the API response but the XSD does not include them as optional fields. Apparently, EPRX has never heard of non-breaking release management!