### PR TITLE
Updated the MarketQuery to allow days to be up to 31 in the future

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mms_client"
-version = "v1.11.0"
+version = "v1.11.1"
 description = "API client for accessing the MMS"
 authors = ["Ryan Wood <ryan.wood@electroroute.co.jp>"]
 readme = "README.md"

--- a/src/mms_client/types/market.py
+++ b/src/mms_client/types/market.py
@@ -46,7 +46,7 @@ class MarketQuery(BaseMarketRequest):
 
     # If the market type is specified as "DAM" (day-ahead market), the number of days should be specified as "1".
     # Otherwise, this field indicates the number of days ahead for which the data is being queried.
-    days: Optional[int] = attr(default=None, name="NumOfDays", ge=1, le=7)
+    days: Optional[int] = attr(default=None, name="NumOfDays", ge=1, le=31)
 
 
 class MarketSubmit(BaseMarketRequest):


### PR DESCRIPTION
This PR relaxes the validation on `MarketQuery.days` to allow for submissions up to 31 days ahead.