### PR TITLE
chore(task-13): update CODEOWNERS for GitHub org rename

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,10 +1,10 @@
 # Ensure that code changes are reviewed by the developers
-* @ElectroRoute-Japan/Developers
+* @EnergyRoute-Japan/Developers
 
 # Ensure that changes to workflows or the codeowners file are reviewed by the Admins
-.gitignore @ElectroRoute-Japan/Admins
-CODEOWNERS @ElectroRoute-Japan/Admins
-LICENSE @ElectroRoute-Japan/Admins
-.pre-commit-config.yaml @ElectroRoute-Japan/Admins
-/.github/ @ElectroRoute-Japan/Admins
-*.sh @ElectroRoute-Japan/Admins
+.gitignore @EnergyRoute-Japan/Admins
+CODEOWNERS @EnergyRoute-Japan/Admins
+LICENSE @EnergyRoute-Japan/Admins
+.pre-commit-config.yaml @EnergyRoute-Japan/Admins
+/.github/ @EnergyRoute-Japan/Admins
+*.sh @EnergyRoute-Japan/Admins


### PR DESCRIPTION
Updates CODEOWNERS team references from `@ElectroRoute-Japan/*` to `@EnergyRoute-Japan/*` following the GitHub organisation rename.

Part of task CU-869d478xw.