### PR TITLE
chore(rename): update ElectroRoute → EnergyRoute/ERJ references

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mms_client"
 version = "v1.12.3"
 description = "API client for accessing the MMS"
-authors = ["Ryan Wood <ryan.wood@electroroute.co.jp>"]
+authors = ["Ryan Wood <ryan.wood@erj.co.jp>"]
 readme = "README.md"
 packages = [{ include = "mms_client", from = "src" }]
 homepage = "https://github.com/EnergyRoute-Japan/mms-client"


### PR DESCRIPTION
## Summary

- Updates author email in `pyproject.toml` from `electroroute.co.jp` to `erj.co.jp`

Part of CU-869d4792q — company rename migration (ElectroRoute Japan → EnergyRoute Japan).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)